### PR TITLE
Scaffold Next.js pricing leaderboard monorepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/node_modules
+/.pnpm-store
+pnpm-lock.yaml
+.env
+/apps/web/.next
+/apps/web/out

--- a/README.md
+++ b/README.md
@@ -1,57 +1,71 @@
 # AI Pricing Leaderboard
 
-Welcome to the AI Pricing Leaderboard project! This repository provides a comprehensive platform to compare and analyze the pricing models of various AI services.
+This monorepo hosts a minimal pricing leaderboard for major AI model providers. It is built with Next.js 15, Tailwind CSS, and Prisma with PostgreSQL. The MVP ships with mock data and seeds so you can explore the UI immediately while preparing real scraping integrations.
 
-## Table of Contents
+## Stack
 
-- [Introduction](#introduction)
-- [Features](#features)
-- [Installation](#installation)
-- [Usage](#usage)
-- [Contributing](#contributing)
-- [License](#license)
+- **Apps**: `apps/web` – Next.js 15 (App Router) with Tailwind CSS and TypeScript.
+- **Database**: PostgreSQL accessed via Prisma inside `packages/db`.
+- **Shared packages**:
+  - `packages/types` – common Zod schemas and TypeScript types.
+  - `packages/utils` – helper utilities (formatting, etc.).
+  - `packages/scrapers` – placeholder modules for future pricing scrapers.
 
-## Introduction
+The repository uses pnpm workspaces to link packages together.
 
-The AI Pricing Leaderboard aims to offer transparency in AI service pricing by aggregating data from multiple providers and presenting it in an easy-to-understand leaderboard format. This helps developers and businesses make informed decisions based on cost-efficiency.
+## Getting started
 
-## Features
+1. Install dependencies:
 
-- Aggregated pricing data from leading AI providers
-- Interactive leaderboard with sorting and filtering options
-- Historical pricing trends visualization
-- API access for integration with other tools
+   ```bash
+   pnpm install
+   ```
 
-## Installation
+2. Provide a `DATABASE_URL` in a `.env` file at the repository root. Example for a local PostgreSQL instance:
 
-To get started with the AI Pricing Leaderboard, clone the repository and install the necessary dependencies:
+   ```bash
+   DATABASE_URL="postgresql://postgres:postgres@localhost:5432/ai_pricing"
+   ```
 
-```bash
-git clone https://github.com/yourusername/ai-pricing-leaderboard.git
-cd ai-pricing-leaderboard
-npm install
+3. Push the Prisma schema and generate the client:
+
+   ```bash
+   pnpm db:migrate
+   pnpm db:generate
+   ```
+
+4. Seed the database with the included mock provider/model data:
+
+   ```bash
+   pnpm db:seed
+   ```
+
+5. Start the development server:
+
+   ```bash
+   pnpm dev
+   ```
+
+   Visit [http://localhost:3000](http://localhost:3000) to see the seeded leaderboard.
+
+## Project structure
+
+```
+.
+├── apps
+│   └── web               # Next.js frontend (App Router)
+├── packages
+│   ├── db                # Prisma client, schema, seed helpers
+│   ├── scrapers          # Placeholder provider scrapers
+│   ├── types             # Zod schemas and shared TS types
+│   └── utils             # Formatting helpers
+└── pnpm-workspace.yaml
 ```
 
-## Usage
+## Next steps
 
-Start the application locally with:
-
-```bash
-npm start
-```
-
-Open your browser and navigate to `http://localhost:3000` to view the leaderboard.
-
-To build the project for production:
-
-```bash
-npm run build
-```
-
-## Contributing
-
-Contributions are welcome! Please fork the repository and submit a pull request with your improvements. Make sure to follow the coding standards and include tests where applicable.
-
-## License
-
-This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
+- Wire up real scrapers inside `packages/scrapers` to populate the database automatically.
+- Expand API routes with filtering, pagination, and historical trend endpoints.
+- Add authentication/role-based access for managing provider data.
+- Layer in charts for historical price movements and provider comparisons.
+- Set up automated tests and linting pipelines with CI.

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript
+

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,0 +1,9 @@
+import type { NextConfig } from 'next';
+
+const config: NextConfig = {
+  experimental: {
+    typedRoutes: true
+  }
+};
+
+export default config;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@ai-pricing-leaderboard/db": "workspace:*",
+    "@ai-pricing-leaderboard/types": "workspace:*",
+    "@ai-pricing-leaderboard/utils": "workspace:*",
+    "@prisma/client": "5.20.0",
+    "next": "15.0.0-canary.48",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.16.5",
+    "autoprefixer": "10.4.20",
+    "eslint": "9.9.0",
+    "eslint-config-next": "15.0.0-canary.48",
+    "postcss": "8.4.45",
+    "tailwindcss": "3.4.10",
+    "typescript": "5.5.4"
+  }
+}

--- a/apps/web/postcss.config.js
+++ b/apps/web/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/apps/web/src/app/api/models/[id]/route.ts
+++ b/apps/web/src/app/api/models/[id]/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { getLeaderboardModelById } from '@ai-pricing-leaderboard/db';
+import { paramsSchema } from '@ai-pricing-leaderboard/types';
+
+export async function GET(_request: Request, context: { params: unknown }) {
+  const parseResult = paramsSchema.safeParse(context.params);
+
+  if (!parseResult.success) {
+    return NextResponse.json({ error: 'Invalid model id' }, { status: 400 });
+  }
+
+  const model = await getLeaderboardModelById(parseResult.data.id);
+
+  if (!model) {
+    return NextResponse.json({ error: 'Model not found' }, { status: 404 });
+  }
+
+  return NextResponse.json({ data: model });
+}

--- a/apps/web/src/app/api/models/route.ts
+++ b/apps/web/src/app/api/models/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+import { getLeaderboardModels } from '@ai-pricing-leaderboard/db';
+
+export async function GET() {
+  const models = await getLeaderboardModels();
+
+  return NextResponse.json({ data: models });
+}

--- a/apps/web/src/app/api/providers/route.ts
+++ b/apps/web/src/app/api/providers/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+import { getProviders } from '@ai-pricing-leaderboard/db';
+
+export async function GET() {
+  const providers = await getProviders();
+  return NextResponse.json({ data: providers });
+}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,0 +1,15 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light dark;
+}
+
+body {
+  @apply min-h-screen bg-slate-950 text-slate-100 antialiased;
+}
+
+a {
+  @apply text-primary-400 hover:text-primary-300 transition-colors;
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,0 +1,38 @@
+import type { Metadata } from 'next';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'AI Pricing Leaderboard',
+  description: 'Compare AI model pricing across providers at a glance.'
+};
+
+export default function RootLayout({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body className="bg-slate-950 text-slate-100">
+        <div className="mx-auto flex min-h-screen max-w-5xl flex-col px-6 py-10">
+          <header className="flex flex-col gap-2 pb-8">
+            <p className="text-sm font-semibold uppercase tracking-wider text-primary-300">
+              AI Pricing Leaderboard
+            </p>
+            <h1 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">
+              Track model pricing across providers
+            </h1>
+            <p className="max-w-2xl text-sm text-slate-300">
+              Stay informed about the latest input and output token pricing across major AI providers. This
+              lightweight MVP pulls seeded data and sets the stage for automated scrapers and richer analytics.
+            </p>
+          </header>
+          <main className="flex-1">{children}</main>
+          <footer className="pt-10 text-xs text-slate-500">
+            Data shown is mocked for development purposes. Connect your database and scrapers to go live.
+          </footer>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,0 +1,29 @@
+import { getLeaderboardModels } from '@ai-pricing-leaderboard/db';
+import { formatUsd } from '@ai-pricing-leaderboard/utils';
+import { LeaderboardTable } from '@/components/LeaderboardTable';
+
+export default async function HomePage() {
+  const models = await getLeaderboardModels();
+  const providerCount = new Set(models.map((m) => m.provider)).size;
+  const lowestInput = models.length > 0 ? Math.min(...models.map((m) => m.inputPrice)) : null;
+
+  return (
+    <section className="space-y-8">
+      <div className="grid gap-4 sm:grid-cols-3">
+        <StatCard label="Providers" value={providerCount.toString()} />
+        <StatCard label="Models" value={models.length.toString()} />
+        <StatCard label="Lowest input" value={lowestInput !== null ? formatUsd(lowestInput) : '—'} />
+      </div>
+      <LeaderboardTable models={models} />
+    </section>
+  );
+}
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+      <p className="text-xs uppercase tracking-wide text-slate-400">{label}</p>
+      <p className="mt-2 text-2xl font-semibold text-white">{value}</p>
+    </div>
+  );
+}

--- a/apps/web/src/components/LeaderboardTable.tsx
+++ b/apps/web/src/components/LeaderboardTable.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import type { LeaderboardModel } from '@ai-pricing-leaderboard/types';
+import { formatUsd } from '@ai-pricing-leaderboard/utils';
+import { useMemo, useState } from 'react';
+
+export type LeaderboardTableProps = {
+  models: LeaderboardModel[];
+};
+
+type SortKey = 'provider' | 'model' | 'inputPrice' | 'outputPrice';
+
+type SortState = {
+  key: SortKey;
+  direction: 'asc' | 'desc';
+};
+
+const headers: { label: string; key: SortKey; align?: 'right' }[] = [
+  { label: 'Provider', key: 'provider' },
+  { label: 'Model', key: 'model' },
+  { label: 'Input / 1M tokens', key: 'inputPrice', align: 'right' },
+  { label: 'Output / 1M tokens', key: 'outputPrice', align: 'right' }
+];
+
+export function LeaderboardTable({ models }: LeaderboardTableProps) {
+  const [sortState, setSortState] = useState<SortState>({ key: 'inputPrice', direction: 'asc' });
+
+  const sortedModels = useMemo(() => {
+    return [...models].sort((a, b) => {
+      const { key, direction } = sortState;
+      const multiplier = direction === 'asc' ? 1 : -1;
+
+      if (key === 'provider' || key === 'model') {
+        return a[key].localeCompare(b[key]) * multiplier;
+      }
+
+      return (a[key] - b[key]) * multiplier;
+    });
+  }, [models, sortState]);
+
+  const handleSort = (key: SortKey) => {
+    setSortState((prev) => {
+      if (prev.key === key) {
+        return { key, direction: prev.direction === 'asc' ? 'desc' : 'asc' };
+      }
+
+      return { key, direction: key === 'provider' || key === 'model' ? 'asc' : 'desc' };
+    });
+  };
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-slate-800 bg-slate-900/70 shadow-xl shadow-primary-950/40">
+      <table className="min-w-full divide-y divide-slate-800 text-sm">
+        <thead className="bg-slate-900/60 text-left text-xs uppercase tracking-wide text-slate-400">
+          <tr>
+            {headers.map(({ label, key, align }) => (
+              <th
+                key={key}
+                scope="col"
+                className={`px-4 py-3 font-semibold ${align === 'right' ? 'text-right' : 'text-left'}`}
+              >
+                <button
+                  type="button"
+                  onClick={() => handleSort(key)}
+                  className="inline-flex items-center gap-1 text-slate-300 transition hover:text-white"
+                >
+                  {label}
+                  {sortState.key === key && (
+                    <span aria-hidden className="text-xs text-primary-300">
+                      {sortState.direction === 'asc' ? '▲' : '▼'}
+                    </span>
+                  )}
+                </button>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-800/80">
+          {sortedModels.map((model) => (
+            <tr key={model.id} className="bg-slate-950/20 hover:bg-slate-900/80">
+              <td className="px-4 py-4 font-medium text-white">{model.provider}</td>
+              <td className="px-4 py-4 text-slate-200">{model.model}</td>
+              <td className="px-4 py-4 text-right font-mono text-slate-100">
+                {formatUsd(model.inputPrice)}
+              </td>
+              <td className="px-4 py-4 text-right font-mono text-slate-100">
+                {formatUsd(model.outputPrice)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -1,0 +1,23 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: [
+    './src/**/*.{ts,tsx}',
+    './src/app/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          50: '#f0f9ff',
+          100: '#e0f2fe',
+          500: '#3b82f6',
+          600: '#2563eb'
+        }
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@/components/*": ["./src/components/*"],
+      "@/lib/*": ["./src/lib/*"]
+    },
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.cjs", "**/*.mjs"],
+  "exclude": ["node_modules"]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "ai-pricing-leaderboard",
+  "private": true,
+  "version": "0.1.0",
+  "packageManager": "pnpm@9.12.0",
+  "scripts": {
+    "dev": "pnpm --filter web dev",
+    "build": "pnpm --filter web build",
+    "lint": "pnpm --filter web lint",
+    "db:generate": "pnpm --filter db prisma generate",
+    "db:migrate": "pnpm --filter db prisma db push",
+    "db:seed": "pnpm --filter db db:seed"
+  }
+}

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@ai-pricing-leaderboard/db",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "prisma": "prisma",
+    "generate": "prisma generate",
+    "db:seed": "prisma db seed"
+  },
+  "dependencies": {
+    "@prisma/client": "5.20.0",
+    "zod": "3.23.8"
+  },
+  "devDependencies": {
+    "prisma": "5.20.0",
+    "tsx": "4.16.2",
+    "typescript": "5.5.4"
+  },
+  "prisma": {
+    "seed": "tsx prisma/seed.ts"
+  }
+}

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1,0 +1,31 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model Provider {
+  id        String   @id @default(cuid())
+  name      String   @unique
+  slug      String   @unique
+  website   String?
+  models    Model[]
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model Model {
+  id                    String   @id @default(cuid())
+  name                  String
+  slug                  String   @unique
+  provider              Provider @relation(fields: [providerId], references: [id])
+  providerId            String
+  inputPricePerMillion  Decimal  @db.Decimal(10, 4)
+  outputPricePerMillion Decimal  @db.Decimal(10, 4)
+  contextWindow         Int?
+  updatedAt             DateTime @updatedAt
+  createdAt             DateTime @default(now())
+}

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -1,0 +1,115 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+const providers = [
+  {
+    name: 'OpenAI',
+    slug: 'openai',
+    website: 'https://openai.com',
+    models: [
+      {
+        name: 'GPT-4.1 Mini',
+        slug: 'gpt-4-1-mini',
+        inputPricePerMillion: 15.0,
+        outputPricePerMillion: 60.0,
+        contextWindow: 128000
+      },
+      {
+        name: 'GPT-4o',
+        slug: 'gpt-4o',
+        inputPricePerMillion: 30.0,
+        outputPricePerMillion: 60.0,
+        contextWindow: 200000
+      }
+    ]
+  },
+  {
+    name: 'Mistral',
+    slug: 'mistral',
+    website: 'https://mistral.ai',
+    models: [
+      {
+        name: 'Mistral Large 2',
+        slug: 'mistral-large-2',
+        inputPricePerMillion: 12.0,
+        outputPricePerMillion: 36.0,
+        contextWindow: 128000
+      },
+      {
+        name: 'Mistral Small',
+        slug: 'mistral-small',
+        inputPricePerMillion: 2.0,
+        outputPricePerMillion: 6.0,
+        contextWindow: 32000
+      }
+    ]
+  },
+  {
+    name: 'Anthropic',
+    slug: 'anthropic',
+    website: 'https://anthropic.com',
+    models: [
+      {
+        name: 'Claude 3.5 Sonnet',
+        slug: 'claude-3-5-sonnet',
+        inputPricePerMillion: 18.0,
+        outputPricePerMillion: 72.0,
+        contextWindow: 200000
+      },
+      {
+        name: 'Claude 3.5 Haiku',
+        slug: 'claude-3-5-haiku',
+        inputPricePerMillion: 3.0,
+        outputPricePerMillion: 15.0,
+        contextWindow: 200000
+      }
+    ]
+  }
+];
+
+async function main() {
+  for (const provider of providers) {
+    await prisma.provider.upsert({
+      where: { slug: provider.slug },
+      update: {
+        name: provider.name,
+        website: provider.website,
+        models: {
+          deleteMany: {},
+          create: provider.models.map((model) => ({
+            name: model.name,
+            slug: model.slug,
+            inputPricePerMillion: model.inputPricePerMillion,
+            outputPricePerMillion: model.outputPricePerMillion,
+            contextWindow: model.contextWindow
+          }))
+        }
+      },
+      create: {
+        name: provider.name,
+        slug: provider.slug,
+        website: provider.website,
+        models: {
+          create: provider.models.map((model) => ({
+            name: model.name,
+            slug: model.slug,
+            inputPricePerMillion: model.inputPricePerMillion,
+            outputPricePerMillion: model.outputPricePerMillion,
+            contextWindow: model.contextWindow
+          }))
+        }
+      }
+    });
+  }
+}
+
+main()
+  .then(async () => {
+    await prisma.$disconnect();
+  })
+  .catch(async (error) => {
+    console.error('Failed to seed database', error);
+    await prisma.$disconnect();
+    process.exit(1);
+  });

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,0 +1,72 @@
+import { PrismaClient } from '@prisma/client';
+import {
+  leaderboardModelSchema,
+  providerSummarySchema,
+  type LeaderboardModel,
+  type ProviderSummary
+} from '@ai-pricing-leaderboard/types';
+
+const globalForPrisma = globalThis as unknown as {
+  prisma?: PrismaClient;
+};
+
+export const prisma = globalForPrisma.prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrisma.prisma = prisma;
+}
+
+export async function getLeaderboardModels(): Promise<LeaderboardModel[]> {
+  const models = await prisma.model.findMany({
+    include: { provider: true },
+    orderBy: {
+      inputPricePerMillion: 'asc'
+    }
+  });
+
+  return models.map((model) =>
+    leaderboardModelSchema.parse({
+      id: model.id,
+      provider: model.provider.name,
+      model: model.name,
+      inputPrice: Number(model.inputPricePerMillion),
+      outputPrice: Number(model.outputPricePerMillion)
+    })
+  );
+}
+
+export async function getLeaderboardModelById(id: string): Promise<LeaderboardModel | null> {
+  const model = await prisma.model.findUnique({
+    where: { id },
+    include: { provider: true }
+  });
+
+  if (!model) {
+    return null;
+  }
+
+  return leaderboardModelSchema.parse({
+    id: model.id,
+    provider: model.provider.name,
+    model: model.name,
+    inputPrice: Number(model.inputPricePerMillion),
+    outputPrice: Number(model.outputPricePerMillion)
+  });
+}
+
+export async function getProviders(): Promise<ProviderSummary[]> {
+  const providers = await prisma.provider.findMany({
+    include: {
+      _count: { select: { models: true } }
+    }
+  });
+
+  return providers.map((provider) =>
+    providerSummarySchema.parse({
+      id: provider.id,
+      name: provider.name,
+      models: provider._count.models,
+      website: provider.website ?? undefined
+    })
+  );
+}

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*", "prisma/**/*"]
+}

--- a/packages/scrapers/package.json
+++ b/packages/scrapers/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@ai-pricing-leaderboard/scrapers",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  }
+}

--- a/packages/scrapers/src/anthropic.ts
+++ b/packages/scrapers/src/anthropic.ts
@@ -1,0 +1,8 @@
+import type { ScraperResult } from './index.js';
+
+export async function fetchAnthropicPricing(): Promise<ScraperResult> {
+  return {
+    provider: 'Anthropic',
+    models: []
+  };
+}

--- a/packages/scrapers/src/index.ts
+++ b/packages/scrapers/src/index.ts
@@ -1,0 +1,12 @@
+export type ScraperResult = {
+  provider: string;
+  models: Array<{
+    name: string;
+    inputPrice: number;
+    outputPrice: number;
+  }>;
+};
+
+export * from './openai.js';
+export * from './mistral.js';
+export * from './anthropic.js';

--- a/packages/scrapers/src/mistral.ts
+++ b/packages/scrapers/src/mistral.ts
@@ -1,0 +1,8 @@
+import type { ScraperResult } from './index.js';
+
+export async function fetchMistralPricing(): Promise<ScraperResult> {
+  return {
+    provider: 'Mistral',
+    models: []
+  };
+}

--- a/packages/scrapers/src/openai.ts
+++ b/packages/scrapers/src/openai.ts
@@ -1,0 +1,8 @@
+import type { ScraperResult } from './index.js';
+
+export async function fetchOpenAiPricing(): Promise<ScraperResult> {
+  return {
+    provider: 'OpenAI',
+    models: []
+  };
+}

--- a/packages/scrapers/tsconfig.json
+++ b/packages/scrapers/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "emitDeclarationOnly": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@ai-pricing-leaderboard/types",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "dependencies": {
+    "zod": "3.23.8"
+  }
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+export const leaderboardModelSchema = z.object({
+  id: z.string(),
+  provider: z.string(),
+  model: z.string(),
+  inputPrice: z.number(),
+  outputPrice: z.number()
+});
+
+export type LeaderboardModel = z.infer<typeof leaderboardModelSchema>;
+
+export const providerSummarySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  models: z.number().nonnegative(),
+  website: z.string().url().optional()
+});
+
+export type ProviderSummary = z.infer<typeof providerSummarySchema>;
+
+export const paramsSchema = z.object({
+  id: z.string().min(1)
+});

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "emitDeclarationOnly": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@ai-pricing-leaderboard/utils",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  }
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,0 +1,11 @@
+export function formatUsd(value: number, options: Intl.NumberFormatOptions = {}) {
+  const formatter = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 2,
+    ...options
+  });
+
+  return formatter.format(value);
+}

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "emitDeclarationOnly": true
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - "apps/*"
+  - "packages/*"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "baseUrl": "."
+  }
+}


### PR DESCRIPTION
## Summary
- set up a pnpm workspace with Next.js web app and shared packages for db, types, utils, and scrapers
- implement Prisma schema with seed data and shared access helpers for querying providers and models
- build a Tailwind-styled leaderboard UI and REST API routes returning seeded pricing data

## Testing
- ⚠️ `pnpm install` *(fails: network access to registry is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4884a48ac83289291a57561ef3066